### PR TITLE
Proper Status

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,8 +2,9 @@
   "powershell.scriptAnalysis.settingsPath": "PSScriptAnalyzerSettings.psd1",
   "powershell.codeFormatting.alignPropertyValuePairs": false,
   "powershell.codeFormatting.newLineAfterCloseBrace": false,
-  "editor.formatOnSave": false,
-  "[markdown]": {
-    "editor.formatOnSave": true
+  "xml.format.preserveEmptyContent": true,
+  "editor.formatOnSave": true,
+  "[powershell]": {
+    "editor.formatOnSave": false
   }
 }

--- a/PowerGit/Formats/LibGit2Sharp.RepositoryStatus.Format.ps1xml
+++ b/PowerGit/Formats/LibGit2Sharp.RepositoryStatus.Format.ps1xml
@@ -1,0 +1,176 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!--
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<Configuration>
+    <DefaultSettings>
+        <EnumerableExpansions>
+            <!--
+                Make sure the RepositoryStatus object is formatted with below CustomControl,
+                not expanded to each FileStatus object
+            -->
+            <EnumerableExpansion>
+                <EntrySelectedBy>
+                    <TypeName>LibGit2Sharp.RepositoryStatus</TypeName>
+                </EntrySelectedBy>
+                <Expand>CoreOnly</Expand>
+            </EnumerableExpansion>
+        </EnumerableExpansions>
+    </DefaultSettings>
+    <Controls>
+        <Control>
+            <Name>Clean</Name>
+            <CustomControl>
+                <CustomEntries>
+                    <CustomEntry>
+                        <CustomItem>
+                            <Text>Nothing to commit, working tree clean</Text>
+                        </CustomItem>
+                    </CustomEntry>
+                </CustomEntries>
+            </CustomControl>
+        </Control>
+        <Control>
+            <!-- Input: LibGit2Sharp.FileStatus[] -->
+            <Name>IndexStatus</Name>
+            <CustomControl>
+                <CustomEntries>
+                    <CustomEntry>
+                        <CustomItem>
+                            <Text>&#27;[4;1mChanges to be committed:&#27;[0m</Text>
+                            <NewLine />
+                            <NewLine />
+                            <ExpressionBinding>
+                                <ScriptBlock>$_</ScriptBlock>
+                                <EnumerateCollection>true</EnumerateCollection>
+                                <CustomControlName>IndexStatusEntry</CustomControlName>
+                            </ExpressionBinding>
+                            <NewLine />
+                        </CustomItem>
+                    </CustomEntry>
+                </CustomEntries>
+            </CustomControl>
+        </Control>
+        <Control>
+            <!-- Input: LibGit2Sharp.FileStatus[] -->
+            <Name>WorkDirStatus</Name>
+            <CustomControl>
+                <CustomEntries>
+                    <CustomEntry>
+                        <CustomItem>
+                            <Text>&#27;[4;1mChanges not staged for commit:&#27;[0m</Text>
+                            <NewLine />
+                            <NewLine />
+                            <ExpressionBinding>
+                                <ScriptBlock>$_</ScriptBlock>
+                                <EnumerateCollection>false</EnumerateCollection>
+                                <CustomControlName>WorkDirStatusEntry</CustomControlName>
+                            </ExpressionBinding>
+                        </CustomItem>
+                    </CustomEntry>
+                </CustomEntries>
+            </CustomControl>
+        </Control>
+        <Control>
+            <!-- Input: LibGit2Sharp.FileStatus with IndexChange -->
+            <Name>IndexStatusEntry</Name>
+            <CustomControl>
+                <CustomEntries>
+                    <CustomEntry>
+                        <CustomItem>
+                            <Frame>
+                                <LeftIndent>2</LeftIndent>
+                                <CustomItem>
+                                    <ExpressionBinding>
+                                        <ScriptBlock>$_.IndexChange.ToColoredString()</ScriptBlock>
+                                    </ExpressionBinding>
+                                    <Text> </Text>
+                                    <ExpressionBinding>
+                                        <PropertyName>FilePath</PropertyName>
+                                    </ExpressionBinding>
+                                    <NewLine />
+                                </CustomItem>
+                            </Frame>
+                        </CustomItem>
+                    </CustomEntry>
+                </CustomEntries>
+            </CustomControl>
+        </Control>
+        <Control>
+            <!-- Input: LibGit2Sharp.FileStatus with WorkDirChange -->
+            <Name>WorkDirStatusEntry</Name>
+            <CustomControl>
+                <CustomEntries>
+                    <CustomEntry>
+                        <CustomItem>
+                            <Frame>
+                                <LeftIndent>2</LeftIndent>
+                                <CustomItem>
+                                    <ExpressionBinding>
+                                        <ScriptBlock>$_.WorkDirChange.ToColoredString()</ScriptBlock>
+                                    </ExpressionBinding>
+                                    <Text> </Text>
+                                    <ExpressionBinding>
+                                        <PropertyName>FilePath</PropertyName>
+                                    </ExpressionBinding>
+                                    <NewLine />
+                                </CustomItem>
+                            </Frame>
+                        </CustomItem>
+                    </CustomEntry>
+                </CustomEntries>
+            </CustomControl>
+        </Control>
+    </Controls>
+    <ViewDefinitions>
+        <View>
+            <!-- Mirrors the git status output -->
+            <Name>Status</Name>
+            <ViewSelectedBy>
+                <TypeName>LibGit2Sharp.RepositoryStatus</TypeName>
+            </ViewSelectedBy>
+            <CustomControl>
+                <CustomEntries>
+                    <CustomEntry>
+                        <CustomItem>
+                            <!-- Clean -->
+                            <ExpressionBinding>
+                                <CustomControlName>Clean</CustomControlName>
+                                <ScriptBlock>$true</ScriptBlock>
+                                <ItemSelectionCondition>
+                                    <ScriptBlock>-not ($_ | ForEach-Object { $_ })</ScriptBlock>
+                                </ItemSelectionCondition>
+                            </ExpressionBinding>
+                            <!-- Dirty, staged changes -->
+                            <ExpressionBinding>
+                                <PropertyName>ChangedInIndex</PropertyName>
+                                <CustomControlName>IndexStatus</CustomControlName>
+                                <ItemSelectionCondition>
+                                    <PropertyName>ChangedInIndex</PropertyName>
+                                </ItemSelectionCondition>
+                            </ExpressionBinding>
+                            <!-- Dirty, unstaged changes -->
+                            <ExpressionBinding>
+                                <PropertyName>ChangedInWorkDir</PropertyName>
+                                <CustomControlName>WorkDirStatus</CustomControlName>
+                                <ItemSelectionCondition>
+                                    <PropertyName>ChangedInWorkDir</PropertyName>
+                                </ItemSelectionCondition>
+                            </ExpressionBinding>
+                        </CustomItem>
+                    </CustomEntry>
+                </CustomEntries>
+            </CustomControl>
+        </View>
+    </ViewDefinitions>
+</Configuration>

--- a/PowerGit/Formats/LibGit2Sharp.StatusEntry.Format.ps1xml
+++ b/PowerGit/Formats/LibGit2Sharp.StatusEntry.Format.ps1xml
@@ -13,68 +13,165 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 <Configuration>
-    <Controls>
-        <Control>
-            <Name>LibGit2SharpStatusEntry-GroupingFormat</Name>
-            <CustomControl>
-                <CustomEntries>
-                    <CustomEntry>
-                        <CustomItem>
-                            <Frame>
-                                <CustomItem>
-                                    <ExpressionBinding>
-                                        <ScriptBlock>
-                                            $label = if ($_.IsStaged) {
-                                                "Changes to be committed:"
-                                            } else {
-                                                "Changes not staged for commit:"
-                                            }
-                                            "`e[1m`e[4m$label`e[0m"
-                                        </ScriptBlock>
-                                    </ExpressionBinding>
-                                    <NewLine />
-                                </CustomItem>
-                            </Frame>
-                        </CustomItem>
-                    </CustomEntry>
-                </CustomEntries>
-            </CustomControl>
-        </Control>
-    </Controls>
     <ViewDefinitions>
         <View>
-            <Name>LibGit2Sharp.StatusEntry</Name>
+            <Name>Table</Name>
             <ViewSelectedBy>
                 <TypeName>LibGit2Sharp.StatusEntry</TypeName>
             </ViewSelectedBy>
-            <GroupBy>
-                <PropertyName>IsStaged</PropertyName>
-                <CustomControlName>LibGit2SharpStatusEntry-GroupingFormat</CustomControlName>
-            </GroupBy>
             <TableControl>
-                <HideTableHeaders></HideTableHeaders>
                 <TableHeaders>
+                    <!--
+                        Important: each StatusEntry contains the status for one file in both the index and the workdir.
+                        A file may have changes in both, so we must display both (and cannot group by staged/not staged).
+                    -->
                     <TableColumnHeader>
-                        <Label>Change</Label>
-                        <Width>3</Width>
+                        <Label>State</Label>
+                        <Alignment>Left</Alignment>
                     </TableColumnHeader>
                     <TableColumnHeader>
                         <Label>FilePath</Label>
+                    </TableColumnHeader>
+                    <TableColumnHeader>
+                        <Label>HeadToIndexRenameDetails</Label>
+                    </TableColumnHeader>
+                    <TableColumnHeader>
+                        <Label>IndexToWorkDirRenameDetails</Label>
                     </TableColumnHeader>
                 </TableHeaders>
                 <TableRowEntries>
                     <TableRowEntry>
                         <TableColumnItems>
                             <TableColumnItem>
-                                <ScriptBlock>$_.Change.ToColoredString()</ScriptBlock>
+                                <PropertyName>State</PropertyName>
                             </TableColumnItem>
                             <TableColumnItem>
                                 <PropertyName>FilePath</PropertyName>
+                            </TableColumnItem>
+                            <TableColumnItem>
+                                <ScriptBlock>
+                                    if ($null -ne $_.HeadToIndexRenameDetails) {
+                                        $_.HeadToIndexRenameDetails.OldFilePath + " -> " + $_.HeadToIndexRenameDetails.NewFilePath
+                                    }
+                                </ScriptBlock>
+                            </TableColumnItem>
+                            <TableColumnItem>
+                                <ScriptBlock>
+                                    if ($null -ne $_.IndexToWorkDirRenameDetails) {
+                                        $_.IndexToWorkDirRenameDetails.OldFilePath + " -> " + $_.IndexToWorkDirRenameDetails.NewFilePath
+                                    }
+                                </ScriptBlock>
                             </TableColumnItem>
                         </TableColumnItems>
                     </TableRowEntry>
                 </TableRowEntries>
             </TableControl>
+        </View>
+        <View>
+            <Name>BadgesTable</Name>
+            <ViewSelectedBy>
+                <TypeName>LibGit2Sharp.StatusEntry</TypeName>
+            </ViewSelectedBy>
+            <TableControl>
+                <TableHeaders>
+                    <!--
+                        Important: each StatusEntry contains the status for one file in both the index and the workdir.
+                        A file may have changes in both, so we must display both (and cannot group by staged/not staged).
+                    -->
+                    <TableColumnHeader>
+                        <Label>WorkDirChange</Label>
+                        <Alignment>Center</Alignment>
+                    </TableColumnHeader>
+                    <TableColumnHeader>
+                        <Label>IndexChange</Label>
+                        <Alignment>Center</Alignment>
+                    </TableColumnHeader>
+                    <TableColumnHeader>
+                        <Label>FilePath</Label>
+                    </TableColumnHeader>
+                    <TableColumnHeader>
+                        <Label>HeadToIndexRenameDetails</Label>
+                    </TableColumnHeader>
+                    <TableColumnHeader>
+                        <Label>IndexToWorkDirRenameDetails</Label>
+                    </TableColumnHeader>
+                </TableHeaders>
+                <TableRowEntries>
+                    <TableRowEntry>
+                        <TableColumnItems>
+                            <TableColumnItem>
+                                <ScriptBlock>
+                                    if ($null -ne $_.WorkDirChange) {
+                                        $_.WorkDirChange.ToColoredString()
+                                    }
+                                </ScriptBlock>
+                            </TableColumnItem>
+                            <TableColumnItem>
+                                <ScriptBlock>
+                                    if ($null -ne $_.IndexChange) {
+                                        $_.IndexChange.ToColoredString()
+                                    }
+                                </ScriptBlock>
+                            </TableColumnItem>
+                            <TableColumnItem>
+                                <PropertyName>FilePath</PropertyName>
+                            </TableColumnItem>
+                            <TableColumnItem>
+                                <ScriptBlock>
+                                    if ($null -ne $_.HeadToIndexRenameDetails) {
+                                        $_.HeadToIndexRenameDetails.OldFilePath + " -> " + $_.HeadToIndexRenameDetails.NewFilePath
+                                    }
+                                </ScriptBlock>
+                            </TableColumnItem>
+                            <TableColumnItem>
+                                <ScriptBlock>
+                                    if ($null -ne $_.IndexToWorkDirRenameDetails) {
+                                        $_.IndexToWorkDirRenameDetails.OldFilePath + " -> " + $_.IndexToWorkDirRenameDetails.NewFilePath
+                                    }
+                                </ScriptBlock>
+                            </TableColumnItem>
+                        </TableColumnItems>
+                    </TableRowEntry>
+                </TableRowEntries>
+            </TableControl>
+        </View>
+        <View>
+            <Name>List</Name>
+            <ViewSelectedBy>
+                <TypeName>LibGit2Sharp.StatusEntry</TypeName>
+            </ViewSelectedBy>
+            <ListControl>
+                <ListEntries>
+                    <ListEntry>
+                        <ListItems>
+                            <ListItem>
+                                <PropertyName>FilePath</PropertyName>
+                            </ListItem>
+                            <ListItem>
+                                <PropertyName>State</PropertyName>
+                            </ListItem>
+                            <ListItem>
+                                <Label>IndexToWorkDirRenameDetails</Label>
+                                <ItemSelectionCondition>
+                                    <PropertyName>IndexToWorkDirRenameDetails</PropertyName>
+                                </ItemSelectionCondition>
+                                <ScriptBlock>
+                                    $_.IndexToWorkDirRenameDetails.OldFilePath + " -> " + $_.IndexToWorkDirRenameDetails.NewFilePath
+                                </ScriptBlock>
+                            </ListItem>
+                            <ListItem>
+                                <Label>HeadToIndexRenameDetails</Label>
+                                <ItemSelectionCondition>
+                                    <PropertyName>HeadToIndexRenameDetails</PropertyName>
+                                </ItemSelectionCondition>
+                                <ScriptBlock>
+                                    $_.HeadToIndexRenameDetails.OldFilePath + " -> " + $_.HeadToIndexRenameDetails.NewFilePath
+                                </ScriptBlock>
+                            </ListItem>
+                        </ListItems>
+                    </ListEntry>
+                </ListEntries>
+            </ListControl>
         </View>
     </ViewDefinitions>
 </Configuration>

--- a/PowerGit/Functions/Compare-GitTree.ps1
+++ b/PowerGit/Functions/Compare-GitTree.ps1
@@ -36,7 +36,6 @@ function Compare-GitTree {
 
     Demonstrates how to get the diff between the commit tagged with `2.0` and the older commit tagged with `1.0` in the repository located at `C:\build\repo`.
     #>
-    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseOutputTypeCorrectly', '')] # needed to prevent enumerable expansion
     [CmdletBinding(DefaultParameterSetName = 'RepoRoot')]
     [OutputType([LibGit2Sharp.TreeChanges])]
     param(
@@ -77,6 +76,6 @@ function Compare-GitTree {
         return
     }
 
-    # use `,` to prevent unwrapping of enumerable TreeChanges type
-    return , $script:getTreeChanges.Invoke($repo.Diff, @($oldCommit.Tree, $newCommit.Tree))
+    [LibGit2Sharp.TreeChanges]$treeChanges = $script:getTreeChanges.Invoke($repo.Diff, @($oldCommit.Tree, $newCommit.Tree))
+    Write-Output -InputObject $treeChanges -NoEnumerate
 }

--- a/PowerGit/Functions/Get-GitStatusPrompt.ps1
+++ b/PowerGit/Functions/Get-GitStatusPrompt.ps1
@@ -60,9 +60,9 @@
                         $counts[$flag]++
                     }
                 }
-                if ($file.IsStaged) {
+                if ($null -ne $file.IndexChange) {
                     $indexIsDirty = $true
-                } else {
+                } elseif ($null -ne $file.WorkDirChange) {
                     $workDirIsDirty = $true
                 }
             }

--- a/PowerGit/Functions/Receive-GitBranch.ps1
+++ b/PowerGit/Functions/Receive-GitBranch.ps1
@@ -85,17 +85,13 @@ function Receive-GitBranch {
 
     if (-not $branch.IsTracking) {
         [LibGit2Sharp.Branch]$remoteBranch = $repo.Branches | Where-Object { $_.UpstreamBranchCanonicalName -eq $branch.CanonicalName }
-    if (-not $remoteBranch) {
-        Write-Error -Message ('Branch "{0}" in repository "{1}" isn''t tracking a remote branch and we''re unable to find a remote branch named "{0}".' -f $branch.FriendlyName, $RepoRoot)
-        return
-    }
+        if (-not $remoteBranch) {
+            Write-Error -Message ('Branch "{0}" in repository "{1}" isn''t tracking a remote branch and we''re unable to find a remote branch named "{0}".' -f $branch.FriendlyName, $RepoRoot)
+            return
+        }
 
-    [void]$repo.Branches.Update($branch, {
-            param(
-                [LibGit2Sharp.BranchUpdater]
-                $Updater
-            )
-
+        [void]$repo.Branches.Update($branch, {
+            param([LibGit2Sharp.BranchUpdater] $Updater)
             $Updater.TrackedBranch = $remoteBranch.CanonicalName
         })
     }

--- a/PowerGit/Functions/Test-GitUncommittedChange.ps1
+++ b/PowerGit/Functions/Test-GitUncommittedChange.ps1
@@ -38,6 +38,8 @@ function Test-GitUncommittedChange {
 
     Set-StrictMode -Version 'Latest'
 
-    $status = Get-GitRepositoryStatus -RepoRoot $RepoRoot 6>$null
-    return [bool]$status
+    [LibGit2Sharp.RepositoryStatus]$status = Get-GitRepositoryStatus -RepoRoot $RepoRoot
+    if ($null -ne $status) {
+        $status.IsDirty
+    }
 }

--- a/PowerGit/PowerGit.psd1
+++ b/PowerGit/PowerGit.psd1
@@ -67,6 +67,7 @@
         'Types/LibGit2Sharp.Commit.Types.ps1xml',
         'Types/LibGit2Sharp.Remote.Types.ps1xml',
         'Types/LibGit2Sharp.Repository.Types.ps1xml',
+        'Types/LibGit2Sharp.RepositoryStatus.Types.ps1xml',
         'Types/LibGit2Sharp.StatusEntry.Types.ps1xml',
         'Types/LibGit2Sharp.Tag.Types.ps1xml'
     )
@@ -74,9 +75,10 @@
     # Format files (.ps1xml) to be loaded when importing this module
     FormatsToProcess = @(
         'Formats/LibGit2Sharp.Branch.Format.ps1xml',
-        'Formats/LibGit2Sharp.Patch.Format.ps1xml',
-        'Formats/LibGit2Sharp.MergeResult.Format.ps1xml',
         'Formats/LibGit2Sharp.Commit.Format.ps1xml',
+        'Formats/LibGit2Sharp.MergeResult.Format.ps1xml',
+        'Formats/LibGit2Sharp.Patch.Format.ps1xml',
+        'Formats/LibGit2Sharp.RepositoryStatus.Format.ps1xml',
         'Formats/LibGit2Sharp.StatusEntry.Format.ps1xml'
     )
 

--- a/PowerGit/Types/LibGit2Sharp.ChangeKind.Types.ps1xml
+++ b/PowerGit/Types/LibGit2Sharp.ChangeKind.Types.ps1xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8" ?>
 <!--
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -23,7 +23,7 @@ limitations under the License.
                         ([LibGit2Sharp.ChangeKind]::Added)       { "`e[42m`e[30m A `e[0m" }
                         ([LibGit2Sharp.ChangeKind]::Modified)    { "`e[43m`e[30m M `e[0m" }
                         ([LibGit2Sharp.ChangeKind]::Deleted)     { "`e[41m`e[30m D `e[0m" }
-                        ([LibGit2Sharp.ChangeKind]::Renamed)     { "`e[48;5;208m`e[30m M `e[0m" }
+                        ([LibGit2Sharp.ChangeKind]::Renamed)     { "`e[48;5;208m`e[30m R `e[0m" }
                         ([LibGit2Sharp.ChangeKind]::Copied)      { "`e[46m`e[30m C `e[0m" }
                         ([LibGit2Sharp.ChangeKind]::Ignored)     { "`e[48;5;247m`e[30m I `e[0m" }
                         ([LibGit2Sharp.ChangeKind]::Conflicted)  { "`e[48;5;124m`e[30m C `e[0m" }

--- a/PowerGit/Types/LibGit2Sharp.RepositoryStatus.Types.ps1xml
+++ b/PowerGit/Types/LibGit2Sharp.RepositoryStatus.Types.ps1xml
@@ -1,0 +1,19 @@
+<Types>
+    <Type>
+        <Name>LibGit2Sharp.RepositoryStatus</Name>
+        <Members>
+            <ScriptProperty>
+                <Name>ChangedInIndex</Name>
+                <GetScriptBlock>
+                    $this | Where-Object { $null -ne $_.IndexChange }
+                </GetScriptBlock>
+            </ScriptProperty>
+            <ScriptProperty>
+                <Name>ChangedInWorkdir</Name>
+                <GetScriptBlock>
+                    $this | Where-Object { $null -ne $_.WorkDirChange }
+                </GetScriptBlock>
+            </ScriptProperty>
+        </Members>
+    </Type>
+</Types>

--- a/PowerGit/Types/LibGit2Sharp.StatusEntry.Types.ps1xml
+++ b/PowerGit/Types/LibGit2Sharp.StatusEntry.Types.ps1xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8" ?>
 <!--
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -21,104 +21,43 @@ limitations under the License.
                 <ReferencedMemberName>FilePath</ReferencedMemberName>
             </AliasProperty>
             <ScriptProperty>
-                <Name>Change</Name>
+                <Name>IndexChange</Name>
                 <GetScriptBlock>
-                    if ($this.IsUntracked) {
-                        [LibGit2Sharp.ChangeKind]::Untracked
-                    } elseif ($this.IsConflicted) {
-                        [LibGit2Sharp.ChangeKind]::Conflicted
-                    } elseif ($this.IsIgnored) {
-                        [LibGit2Sharp.ChangeKind]::Ignored
-                    } elseif ($this.IsUnreadable) {
-                        [LibGit2Sharp.ChangeKind]::Unreadable
-                    } elseif ($this.IsModified) {
-                        [LibGit2Sharp.ChangeKind]::Modified
-                    } elseif ($this.IsAdded) {
-                        [LibGit2Sharp.ChangeKind]::Added
-                    } elseif ($this.IsDeleted) {
-                        [LibGit2Sharp.ChangeKind]::Deleted
-                    } elseif ($this.IsRenamed) {
+                    if ($this.State.HasFlag([LibGit2Sharp.FileStatus]::RenamedInIndex)) {
                         [LibGit2Sharp.ChangeKind]::Renamed
-                    } elseif ($this.IsTypeChanged) {
+                    } elseif ($this.State.HasFlag([LibGit2Sharp.FileStatus]::NewInIndex)) {
+                        [LibGit2Sharp.ChangeKind]::Added
+                    } elseif ($this.State.HasFlag([LibGit2Sharp.FileStatus]::TypeChangeInIndex)) {
                         [LibGit2Sharp.ChangeKind]::TypeChanged
-                    } elseif ($this.IsUnchanged) {
-                        [LibGit2Sharp.ChangeKind]::Unchanged
+                    } elseif ($this.State.HasFlag([LibGit2Sharp.FileStatus]::DeletedFromIndex)) {
+                        [LibGit2Sharp.ChangeKind]::Deleted
+                    } elseif ($this.State.HasFlag([LibGit2Sharp.FileStatus]::ModifiedInIndex)) {
+                        [LibGit2Sharp.ChangeKind]::Modified
                     }
                 </GetScriptBlock>
             </ScriptProperty>
             <ScriptProperty>
-                <Name>IsStaged</Name>
+                <Name>WorkDirChange</Name>
                 <GetScriptBlock>
-                    return $this.State.HasFlag([LibGit2Sharp.FileStatus]::NewInIndex) -or `
-                        $this.State.HasFlag([LibGit2Sharp.FileStatus]::ModifiedInIndex) -or `
-                        $this.State.HasFlag([LibGit2Sharp.FileStatus]::DeletedFromIndex) -or `
-                        $this.State.HasFlag([LibGit2Sharp.FileStatus]::RenamedInIndex) -or `
-                        $this.State.HasFlag([LibGit2Sharp.FileStatus]::TypeChangeInIndex)
-                </GetScriptBlock>
-            </ScriptProperty>
-            <ScriptProperty>
-                <Name>IsUnchanged</Name>
-                <GetScriptBlock>
-                    return $this.State -eq [LibGit2Sharp.FileStatus]::Unaltered
-                </GetScriptBlock>
-            </ScriptProperty>
-            <ScriptProperty>
-                <Name>IsIgnored</Name>
-                <GetScriptBlock>
-                    return $this.State.HasFlag([LibGit2Sharp.FileStatus]::Ignored)
-                </GetScriptBlock>
-            </ScriptProperty>
-            <ScriptProperty>
-                <Name>IsUntracked</Name>
-                <GetScriptBlock>
-                    return $this.State.HasFlag([LibGit2Sharp.FileStatus]::NewInWorkdir)
-                </GetScriptBlock>
-            </ScriptProperty>
-            <ScriptProperty>
-                <Name>IsAdded</Name>
-                <GetScriptBlock>
-                    return $this.State.HasFlag([LibGit2Sharp.FileStatus]::NewInIndex) -or `
-                        $this.State.HasFlag([LibGit2Sharp.FileStatus]::NewInWorkdir)
-                </GetScriptBlock>
-            </ScriptProperty>
-            <ScriptProperty>
-                <Name>IsModified</Name>
-                <GetScriptBlock>
-                    return $this.State.HasFlag([LibGit2Sharp.FileStatus]::ModifiedInIndex) -or `
-                        $this.State.HasFlag([LibGit2Sharp.FileStatus]::ModifiedInWorkdir)
-                </GetScriptBlock>
-            </ScriptProperty>
-            <ScriptProperty>
-                <Name>IsDeleted</Name>
-                <GetScriptBlock>
-                    return $this.State.HasFlag([LibGit2Sharp.FileStatus]::DeletedFromIndex) -or `
-                        $this.State.HasFlag([LibGit2Sharp.FileStatus]::DeletedFromWorkdir)
-                </GetScriptBlock>
-            </ScriptProperty>
-            <ScriptProperty>
-                <Name>IsRenamed</Name>
-                <GetScriptBlock>
-                    return $this.State.HasFlag([LibGit2Sharp.FileStatus]::RenamedInIndex) -or `
-                        $this.State.HasFlag([LibGit2Sharp.FileStatus]::RenamedInWorkdir)
-                </GetScriptBlock>
-            </ScriptProperty>
-            <ScriptProperty>
-                <Name>IsTypeChanged</Name>
-                <GetScriptBlock>
-                    return $this.State.HasFlag([LibGit2Sharp.FileStatus]::TypeChangedInIndex) -or `
-                        $this.State.HasFlag([LibGit2Sharp.FileStatus]::TypeChangedInWorkdir)
-                </GetScriptBlock>
-            </ScriptProperty>
-            <ScriptProperty>
-                <Name>IsUnreadable</Name>
-                <GetScriptBlock>
-                    return $this.State.HasFlag([LibGit2Sharp.FileStatus]::Unreadable)
-                </GetScriptBlock>
-            </ScriptProperty>
-            <ScriptProperty>
-                <Name>IsConflicted</Name>
-                <GetScriptBlock>
-                    return $this.State.HasFlag([LibGit2Sharp.FileStatus]::Conflicted)
+                    if ($this.State.HasFlag([LibGit2Sharp.FileStatus]::NewInWorkdir)) {
+                        [LibGit2Sharp.ChangeKind]::Untracked
+                    } elseif ($this.State.HasFlag([LibGit2Sharp.FileStatus]::Conflicted)) {
+                        [LibGit2Sharp.ChangeKind]::Conflicted
+                    } elseif ($this.State.HasFlag([LibGit2Sharp.FileStatus]::Ignored)) {
+                        [LibGit2Sharp.ChangeKind]::Ignored
+                    } elseif ($this.State.HasFlag([LibGit2Sharp.FileStatus]::Unreadable)) {
+                        [LibGit2Sharp.ChangeKind]::Unreadable
+                    } elseif ($this.State.HasFlag([LibGit2Sharp.FileStatus]::ModifiedInWorkdir)) {
+                        [LibGit2Sharp.ChangeKind]::Modified
+                    } elseif ($this.State.HasFlag([LibGit2Sharp.FileStatus]::RenamedInWorkdir)) {
+                        [LibGit2Sharp.ChangeKind]::Added
+                    } elseif ($this.State.HasFlag([LibGit2Sharp.FileStatus]::DeletedFromWorkdir)) {
+                        [LibGit2Sharp.ChangeKind]::Deleted
+                    } elseif ($this.State.HasFlag([LibGit2Sharp.FileStatus]::TypeChangeInWorkdir)) {
+                        [LibGit2Sharp.ChangeKind]::TypeChanged
+                    } elseif ($this.State.HasFlag([LibGit2Sharp.FileStatus]::Unaltered)) {
+                        [LibGit2Sharp.ChangeKind]::Unaltered
+                    }
                 </GetScriptBlock>
             </ScriptProperty>
         </Members>

--- a/Tests/Add-GitItem.Tests.ps1
+++ b/Tests/Add-GitItem.Tests.ps1
@@ -22,9 +22,7 @@ function Assert-FileNotStaged {
     )
 
     foreach ($pathItem in $Path) {
-        Get-GitRepositoryStatus -RepoRoot $RepoRoot -Path $pathItem 6>$null |
-            Where-Object { $_.IsStaged } |
-            Should -BeNullOrEmpty
+        (Get-GitRepositoryStatus -RepoRoot $RepoRoot -Path $pathItem).ChangedInIndex | Should -BeNullOrEmpty
     }
 }
 function Assert-FileStaged {
@@ -37,9 +35,7 @@ function Assert-FileStaged {
     )
 
     foreach ($pathItem in $Path) {
-        Get-GitRepositoryStatus -RepoRoot $RepoRoot -Path $pathItem |
-            Where-Object { $_.IsStaged } |
-            Should -Not -BeNullOrEmpty
+        (Get-GitRepositoryStatus -RepoRoot $RepoRoot -Path $pathItem).ChangedInIndex | Should -Not -BeNullOrEmpty
     }
 }
 
@@ -49,8 +45,6 @@ Describe Add-GitItem {
         $repoRoot = New-GitTestRepo
         Add-GitTestFile -RepoRoot $repoRoot -Path 'file1', 'file2', 'file3', 'file4'
         Add-GitItem -Path (Join-Path -Path $repoRoot -ChildPath 'file1'), (Join-Path -Path $repoRoot -ChildPath 'file2') -RepoRoot $repoRoot
-
-        $status = Get-GitRepositoryStatus -RepoRoot $repoRoot -Path 'file1'
 
         Assert-FileStaged -Path 'file1', 'file2' -RepoRoot $repoRoot
         Assert-FileNotStaged -Path 'file3', 'file4' -RepoRoot $repoRoot

--- a/Tests/Get-GitRepositoryStatus.Tests.ps1
+++ b/Tests/Get-GitRepositoryStatus.Tests.ps1
@@ -49,22 +49,38 @@ Describe 'Get-GitRepositoryStatus when getting status' {
     'modified' | Set-Content -Path $modifiedPath
 
     It 'should show files modified in the working directory' {
-        Get-GitRepositoryStatus -RepoRoot $repoRoot | Where-Object { $_.FilePath -eq 'modified' } | Select-Object -ExpandProperty 'State' | Should -Be ([LibGit2Sharp.FileStatus]::ModifiedInWorkdir)
+        Get-GitRepositoryStatus -RepoRoot $repoRoot |
+            ForEach-Object { $_ } |
+            Where-Object { $_.FilePath -eq 'modified' } |
+            Select-Object -ExpandProperty 'State' |
+            Should -Be ([LibGit2Sharp.FileStatus]::ModifiedInWorkdir)
     }
 
     Add-GitItem -Path $modifiedPath -RepoRoot $repoRoot
     It 'should show staged files' {
-        Get-GitRepositoryStatus -RepoRoot $repoRoot | Where-Object { $_.FilePath -eq 'modified' } | Select-Object -ExpandProperty 'State' | Should -Be ([LibGit2Sharp.FileStatus]::ModifiedInIndex)
+        Get-GitRepositoryStatus -RepoRoot $repoRoot |
+            ForEach-Object { $_ } |
+            Where-Object { $_.FilePath -eq 'modified' } |
+            Select-Object -ExpandProperty 'State' |
+            Should -Be ([LibGit2Sharp.FileStatus]::ModifiedInIndex)
     }
 
     git -C $repoRoot rm $removedPath
     It 'should show removed files' {
-        Get-GitRepositoryStatus -RepoRoot $repoRoot | Where-Object { $_.FilePath -eq 'removed' } | Select-Object -ExpandProperty 'State' | Should -Be ([LibGit2Sharp.FileStatus]::DeletedFromIndex)
+        Get-GitRepositoryStatus -RepoRoot $repoRoot |
+            ForEach-Object { $_ } |
+            Where-Object { $_.FilePath -eq 'removed' } |
+            Select-Object -ExpandProperty 'State' |
+            Should -Be ([LibGit2Sharp.FileStatus]::DeletedFromIndex)
     }
 
     Remove-Item -Path $missingPath
     It 'should show missing files' {
-        Get-GitRepositoryStatus -RepoRoot $repoRoot | Where-Object { $_.FilePath -eq 'missing' } | Select-Object -ExpandProperty 'State' | Should -Be ([LibGit2Sharp.FileStatus]::DeletedFromWorkdir)
+        Get-GitRepositoryStatus -RepoRoot $repoRoot |
+            ForEach-Object { $_ } |
+            Where-Object { $_.FilePath -eq 'missing' } |
+            Select-Object -ExpandProperty 'State' |
+            Should -Be ([LibGit2Sharp.FileStatus]::DeletedFromWorkdir)
     }
 
     git -C $repoRoot mv $renamedPath (Join-Path -Path $repoRoot -ChildPath 'renamed2')
@@ -86,7 +102,10 @@ Describe 'Get-GitRepositoryStatus when items are ignored' {
 
     Context 'IncludeIgnored switch isn''t used' {
         It 'should not show ignored files' {
-            Get-GitRepositoryStatus -RepoRoot $repoRoot | Select-Object -ExpandProperty 'FilePath' | Should -Be '.gitignore'
+            Get-GitRepositoryStatus -RepoRoot $repoRoot |
+                ForEach-Object { $_ } |
+                Select-Object -ExpandProperty 'FilePath' |
+                Should -Be '.gitignore'
         }
     }
 
@@ -130,7 +149,10 @@ Describe 'Get-GitRepositoryStatus when getting status of explicit paths' {
 
     Context 'Path parameter contains absolute paths' {
         It 'should get only paths specified' {
-            Get-GitRepositoryStatus -RepoRoot $repoRoot -Path $file1Path | Select-Object -ExpandProperty 'FilePath' | Should -Be 'file1'
+            Get-GitRepositoryStatus -RepoRoot $repoRoot -Path $file1Path |
+                ForEach-Object { $_ } |
+                Select-Object -ExpandProperty 'FilePath' |
+                Should -Be 'file1'
         }
     }
 
@@ -139,19 +161,28 @@ Describe 'Get-GitRepositoryStatus when getting status of explicit paths' {
     try {
         Context 'Path parameter is single path' {
             It 'should get only a specific path' {
-                Get-GitRepositoryStatus -Path 'file1' | Select-Object -ExpandProperty 'FilePath' | Should -Be 'file1'
+                Get-GitRepositoryStatus -Path 'file1' |
+                    ForEach-Object { $_ } |
+                    Select-Object -ExpandProperty 'FilePath' |
+                    Should -Be 'file1'
             }
         }
 
         Context 'Path parameter is multiple paths' {
             It 'should get only paths specified' {
-                Get-GitRepositoryStatus -Path 'file1', 'file2' | Select-Object -ExpandProperty 'FilePath' | Should Match 'file(1|2)'
+                Get-GitRepositoryStatus -Path 'file1', 'file2' |
+                    ForEach-Object { $_ } |
+                    Select-Object -ExpandProperty 'FilePath' |
+                    Should Match 'file(1|2)'
             }
         }
 
         Context 'Path parameter contains wildcard paths' {
             It 'should get only paths specified' {
-                Get-GitRepositoryStatus -Path '*1' | Select-Object -ExpandProperty 'FilePath' | Should -Be 'file1'
+                Get-GitRepositoryStatus -Path '*1' |
+                    ForEach-Object { $_ } |
+                    Select-Object -ExpandProperty 'FilePath' |
+                    Should -Be 'file1'
             }
         }
 
@@ -162,20 +193,34 @@ Describe 'Get-GitRepositoryStatus when getting status of explicit paths' {
             try {
                 '' | Set-Content -Path 'file4'
                 It 'should only get paths under that directory' {
-                    Get-GitRepositoryStatus '.' | Select-Object -ExpandProperty 'FilePath' | Should -Be 'dir1/file4' # Expect forward slashes from LibGit2Sharp
+                    Get-GitRepositoryStatus '.' |
+                        ForEach-Object { $_ } |
+                        Select-Object -ExpandProperty 'FilePath' |
+                        Should -Be 'dir1/file4' # Expect forward slashes from LibGit2Sharp
                 }
 
                 It 'should get paths under parent directory' {
                     $status = Get-GitRepositoryStatus '..'
-                    $status | Select-Object -ExpandProperty 'FilePath' | Where-Object { $_ -match 'file(1|2|3)$' } | Should Not BeNullOrEmpty
-                    $status | Select-Object -ExpandProperty 'FilePath' | Where-Object { $_ -match 'file4$' } | Should Not BeNullOrEmpty
+                    $status |
+                        ForEach-Object { $_ } |
+                        Select-Object -ExpandProperty 'FilePath' |
+                        Where-Object { $_ -match 'file(1|2|3)$' } |
+                        Should -Not -BeNullOrEmpty
+                    $status |
+                        ForEach-Object { $_ } |
+                        Select-Object -ExpandProperty 'FilePath' |
+                        Where-Object { $_ -match 'file4$' } |
+                        Should -Not -BeNullOrEmpty
                 }
             } finally {
                 Pop-Location
             }
 
             It 'should get specific item under a directory' {
-                Get-GitRepositoryStatus 'dir1/file4' | Select-Object -ExpandProperty 'FilePath' | Should Not BeNullOrEmpty
+                Get-GitRepositoryStatus 'dir1/file4' |
+                    ForEach-Object { $_ } |
+                    Select-Object -ExpandProperty 'FilePath' |
+                    Should -Not -BeNullOrEmpty
             }
         }
     } finally {
@@ -186,7 +231,10 @@ Describe 'Get-GitRepositoryStatus when getting status of explicit paths' {
         $dir1Path = Join-Path -Path $repoRoot -ChildPath 'dir1'
         '' | Set-Content -Path (Join-Path -Path $dir1Path -ChildPath 'file4')
         It 'should only get paths under that directory' {
-            Get-GitRepositoryStatus 'dir1' -RepoRoot $repoRoot | Select-Object -ExpandProperty 'FilePath' | Should -Be 'dir1/file4' # Expect forward slashes from LibGit2Sharp
+            Get-GitRepositoryStatus 'dir1' -RepoRoot $repoRoot |
+                ForEach-Object { $_ } |
+                Select-Object -ExpandProperty 'FilePath' |
+                Should -Be 'dir1/file4' # Expect forward slashes from LibGit2Sharp
         }
     }
 }

--- a/Tests/Remove-GitItem.Tests.ps1
+++ b/Tests/Remove-GitItem.Tests.ps1
@@ -69,11 +69,8 @@ function ThenFileShouldBeStaged {
 
     foreach ( $pathItem in $Path ) {
         It ('should stage {0}' -f $pathItem) {
-            Get-GitRepositoryStatus -RepoRoot $repoRoot -Path $pathItem |
-                Where-Object { $_.IsStaged } |
-                Measure-Object |
-                Select-Object -ExpandProperty 'Count' |
-                Should -Be 1
+            $status = Get-GitRepositoryStatus -RepoRoot $repoRoot -Path $pathItem
+            $status.ChangedInIndex | Should -HaveCount 1
         }
     }
 }
@@ -86,11 +83,8 @@ function ThenFileShouldNotBeStaged {
 
     foreach ( $pathItem in $Path ) {
         It ('should not stage {0}' -f $pathItem) {
-            Get-GitRepositoryStatus -RepoRoot $repoRoot -Path $pathItem 6>$null |
-                Where-Object { $_.IsStaged } |
-                Measure-Object |
-                Select-Object -ExpandProperty 'Count' |
-                Should -Be 0
+            $status = Get-GitRepositoryStatus -RepoRoot $repoRoot -Path $pathItem 6>$null
+            $status.ChangedInIndex | Should -BeNullOrEmpty
         }
     }
 }


### PR DESCRIPTION
Previously, it was not possible to show files that changed both in the index and the workdir.

Adds a CustomControl for RepositoryStatus and outputs that instead of the FileStatus objects.